### PR TITLE
feat: add Homebrew formula for macOS installation

### DIFF
--- a/Formula/iflow-cli.rb
+++ b/Formula/iflow-cli.rb
@@ -1,0 +1,17 @@
+class IflowCli < Formula
+  desc "AI-powered CLI that embeds in your terminal for coding tasks and workflow automation"
+  homepage "https://platform.iflow.cn"
+  url "https://registry.npmjs.org/@iflow-ai/iflow-cli/-/iflow-cli-0.5.14.tgz"
+  sha256 "7d715c3dc611e3134aaa96a1f68467471b2c50c9b04fba093f4bc4b2ad17b599"
+
+  depends_on "node@22"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match "iflow", shell_output("#{bin}/iflow --version 2>&1", 0)
+  end
+end


### PR DESCRIPTION
## Summary

Add a Homebrew formula (`Formula/iflow-cli.rb`) to support installing iflow-cli via Homebrew on macOS.

## Motivation

The current installation methods require either running a shell script or having Node.js pre-installed. Homebrew is the de facto package manager on macOS, and supporting it would:

- Provide a familiar, one-command install experience for macOS users
- Handle Node.js dependency automatically
- Enable easy upgrades via `brew upgrade iflow-cli`
- Follow macOS ecosystem conventions

## Usage

To use this formula, you would need to create a `homebrew-iflow` repository under the `iflow-ai` org, then users can install with:

```bash
brew tap iflow-ai/iflow
brew install iflow-cli
```

Alternatively, the quickstart docs could be updated to:

```
# macOS (Homebrew)
brew tap iflow-ai/iflow
brew install iflow-cli

# macOS/Linux (shell script)
bash -c "$(curl -fsSL https://gitee.com/iflow-ai/iflow-cli/raw/main/install.sh)"

# Already have Node.js 22+
npm i -g @iflow-ai/iflow-cli@latest
```

## Testing

- ✅ Tested on macOS arm64 (Apple Silicon, macOS Tahoe)
- ✅ `brew install` completes successfully
- ✅ `iflow --version` returns `0.5.14`
- ✅ Node.js 22 dependency resolved automatically

## Next Steps

1. Create `iflow-ai/homebrew-iflow` repo on GitHub
2. Copy `Formula/iflow-cli.rb` into it
3. Update install docs to include Homebrew option
4. (Optional) Set up CI to auto-bump formula on new npm releases